### PR TITLE
Add missing registrations

### DIFF
--- a/src/OpenApi.Extensions/OpenApiExtensions.cs
+++ b/src/OpenApi.Extensions/OpenApiExtensions.cs
@@ -121,6 +121,12 @@ public static class OpenApiExtensions
             var extensions = other.Value;
             configureOptions(options, extensions);
 
+            // TODO Register as the instance
+            var addDescriptions = new AddDescriptionsTransformer();
+            var addResponses = new AddResponseDescriptionsTransformer();
+            options.UseOperationTransformer(addDescriptions.TransformAsync);
+            options.UseOperationTransformer(addResponses.TransformAsync);
+
             if (extensions.AddServerUrls)
             {
                 options.UseTransformer<AddServersTransformer>();

--- a/tests/OpenApi.Extensions.Tests/DocumentTests.Schema_Is_Correct.verified.txt
+++ b/tests/OpenApi.Extensions.Tests/DocumentTests.Schema_Is_Correct.verified.txt
@@ -29,7 +29,7 @@
         ],
         responses: {
           200: {
-            description: OK,
+            description: A greeting.,
             content: {
               application/json: {
                 schema: {


### PR DESCRIPTION
Fix `AddDescriptionsTransformer` and `AddResponseDescriptionsTransformer` not being used.
