### PR TITLE
Enable additional workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,7 @@ jobs:
       package-version: ${{ steps.build.outputs.package-version }}
 
     permissions:
-      # TODO Enable when the repository is public
-      #attestations: write
+      attestations: write
       contents: write
       id-token: write
 
@@ -66,8 +65,6 @@ jobs:
 
     - uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
       name: Upload coverage to Codecov
-      # TODO Enable when repository set up
-      if: false
       with:
         file: ./artifacts/coverage/coverage.cobertura.xml
         flags: ${{ matrix.os-name }}
@@ -83,12 +80,10 @@ jobs:
 
     - name: Attest artifacts
       uses: actions/attest-build-provenance@5e9cb68e95676991667494a6a4e59b8a2f13e1d0 # v1.3.3
-      # TODO Enable when the repository is public
-      if: false
-      #if: |
-      #  runner.os == 'Windows' &&
-      #  github.event.repository.fork == false &&
-      #  (github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/v'))
+      if: |
+        runner.os == 'Windows' &&
+        github.event.repository.fork == false &&
+        (github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/v'))
       with:
         subject-path: |
           ./artifacts/bin/MartinCostello.OpenApi.Extensions/release*/*.dll

--- a/.github/workflows/code-scan.yml
+++ b/.github/workflows/code-scan.yml
@@ -20,8 +20,6 @@ jobs:
   code-ql:
 
     runs-on: ubuntu-latest
-    # TODO Enable once repository is public
-    if: false
 
     permissions:
       security-events: write

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,8 +13,6 @@ permissions:
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
-    # TODO Enable once repository is public
-    if: false
 
     steps:
 

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -12,8 +12,6 @@ permissions: read-all
 
 jobs:
   analysis:
-    # TODO Enable once repository is public
-    if: false
     name: analysis
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,10 @@
 # OpenAPI Extensions
 
-<!--
 [![NuGet][package-badge]][package-download]
--->
 
 [![Build status][build-badge]][build-status]
-
-<!--
 [![codecov][coverage-badge]][coverage-report]
 [![OpenSSF Scorecard][scorecard-badge]][scorecard-report]
--->
 
 ## Introduction
 
@@ -43,19 +38,13 @@ This project is licensed under the [Apache 2.0][license] license.
 [aspnetcore-openapi]: https://www.nuget.org/packages/Microsoft.AspNetCore.OpenApi
 [build-badge]: https://github.com/martincostello/openapi-extensions/actions/workflows/build.yml/badge.svg?branch=main&event=push
 [build-status]: https://github.com/martincostello/openapi-extensions/actions?query=workflow%3Abuild+branch%3Amain+event%3Apush "Continuous Integration for this project"
-<!--
 [coverage-badge]: https://codecov.io/gh/martincostello/openapi-extensions/branch/main/graph/badge.svg
 [coverage-report]: https://codecov.io/gh/martincostello/openapi-extensions "Code coverage report for this project"
--->
 [dotnet-sdk]: https://dotnet.microsoft.com/download "Download the .NET SDK"
 [issues]: https://github.com/martincostello/openapi-extensions/issues "Issues for this project on GitHub.com"
 [license]: https://www.apache.org/licenses/LICENSE-2.0.txt "The Apache 2.0 license"
-<!--
 [package-badge]: https://buildstats.info/nuget/MartinCostello.OpenApi.Extensions?includePreReleases=true
 [package-download]: https://www.nuget.org/packages/MartinCostello.OpenApi.Extensions "Download MartinCostello.OpenApi.Extensions from NuGet"
--->
 [repo]: https://github.com/martincostello/openapi-extensions "This project on GitHub.com"
-<!--
 [scorecard-badge]: https://api.securityscorecards.dev/projects/github.com/martincostello/openapi-extensions/badge
 [scorecard-report]: https://securityscorecards.dev/viewer/?uri=github.com/martincostello/openapi-extensions "OpenSSF Scorecard for this project"
--->


### PR DESCRIPTION
- Enable workflows that can run now the repo is public.
- Enable artifact attestations.
- Add codecov, NuGet and OpenSSF scorecard badges.
