### PR TITLE
Support third party types

### DIFF
--- a/src/OpenApi.Extensions/OpenApiEndpointConventionBuilderExtensions.cs
+++ b/src/OpenApi.Extensions/OpenApiEndpointConventionBuilderExtensions.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Builder;
+
+namespace MartinCostello.OpenApi;
+
+/// <summary>
+/// A class containing methods for adding routing metadata to endpoint
+/// instances for OpenAPI using <see cref="IEndpointConventionBuilder"/>.
+/// This class cannot be inherited.
+/// </summary>
+public static class OpenApiEndpointConventionBuilderExtensions
+{
+    /// <summary>
+    /// Adds OpenAPI response metadata to <see cref="EndpointBuilder.Metadata"/> for all builders produced by builder.
+    /// </summary>
+    /// <typeparam name="TBuilder">The type of the endpoint convention builder.</typeparam>
+    /// <param name="builder">The <see cref="IEndpointConventionBuilder"/>.</param>
+    /// <param name="statusCode">The HTTP status code for the response.</param>
+    /// <param name="description">The description of the response.</param>
+    /// <returns>
+    /// The current <typeparamref name="TBuilder"/> instance for chaining.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="builder"/> is <see langword="null"/>.
+    /// </exception>
+    public static TBuilder ProducesOpenApiResponse<TBuilder>(this TBuilder builder, int statusCode, string description)
+        where TBuilder : IEndpointConventionBuilder
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        return builder.WithMetadata(new OpenApiResponseAttribute(statusCode, description));
+    }
+}

--- a/src/OpenApi.Extensions/OpenApiExtensions.cs
+++ b/src/OpenApi.Extensions/OpenApiExtensions.cs
@@ -140,8 +140,11 @@ public static class OpenApiExtensions
                     throw new InvalidOperationException($"No {nameof(JsonSerializerContext)} has been configured on the {nameof(OpenApiExtensionsOptions)} instance for the OpenAPI document \"{options.DocumentName}\".");
                 }
 
+                var examples = new AddExamplesTransformer(
+                    extensions.ExamplesMetadata,
+                    extensions.SerializationContext);
+
                 // TODO Register as the instance
-                var examples = new AddExamplesTransformer(extensions.SerializationContext);
                 options.UseOperationTransformer(examples.TransformAsync);
                 options.UseSchemaTransformer(examples.TransformAsync);
             }

--- a/src/OpenApi.Extensions/OpenApiExtensionsOptions.cs
+++ b/src/OpenApi.Extensions/OpenApiExtensionsOptions.cs
@@ -59,6 +59,19 @@ public class OpenApiExtensionsOptions
     ];
 
     /// <summary>
+    /// Gets a collection of metadata to use when adding examples to OpenAPI operations and schemas.
+    /// </summary>
+    /// <remarks>
+    /// By default example metadata is searched for in the metadata for endpoints, as well as on
+    /// their parameters and parameter and return types. This collection can be used to provide examples
+    /// for types and/or endpoints where the examples cannot be inferred from the metadata.
+    /// <para/>
+    /// For example, this property can be used to add metadata for types for code you cannot change
+    /// the definition of, such as types from a third-party library or ASP.NET Core itself.
+    /// </remarks>
+    public ICollection<IOpenApiExampleMetadata> ExamplesMetadata { get; } = [];
+
+    /// <summary>
     /// Gets or sets the <see cref="JsonSerializerContext"/> to use
     /// when <see cref="AddExamples"/> is <see langword="true"/>.
     /// </summary>
@@ -69,6 +82,21 @@ public class OpenApiExtensionsOptions
     /// to provide descriptions for operations and/or schemas, if any.
     /// </summary>
     public IList<Assembly> XmlDocumentationAssemblies { get; } = [];
+
+    /// <summary>
+    /// Adds an example provider for the specified type to the options.
+    /// </summary>
+    /// <typeparam name="TSchema">The type of the schema.</typeparam>
+    /// <typeparam name="TProvider">The type of the example provider.</typeparam>
+    /// <returns>
+    /// The current instance of <see cref="OpenApiExtensionsOptions"/>.
+    /// </returns>
+    public OpenApiExtensionsOptions AddExample<TSchema, TProvider>()
+        where TProvider : IExampleProvider<TSchema>
+    {
+        ExamplesMetadata.Add(new OpenApiExampleAttribute<TSchema, TProvider>());
+        return this;
+    }
 
     /// <summary>
     /// Adds XML documentation for the assembly associated with the specified type to the options.

--- a/tests/OpenApi.Extensions.Tests/DocumentTests.Schema_Is_Correct.verified.txt
+++ b/tests/OpenApi.Extensions.Tests/DocumentTests.Schema_Is_Correct.verified.txt
@@ -20,9 +20,8 @@
             name: name,
             in: query,
             description: The name of the person to greet.,
-            required: true,
             schema: {
-              type: string
+              $ref: #/components/schemas/string
             },
             example: Martin
           }
@@ -36,8 +35,7 @@
                   type: object,
                   properties: {
                     text: {
-                      type: string,
-                      nullable: true
+                      $ref: #/components/schemas/string
                     }
                   }
                 },
@@ -46,8 +44,52 @@
                 }
               }
             }
+          },
+          400: {
+            description: No name was provided.,
+            content: {
+              application/problem+json: {
+                schema: {
+                  type: object,
+                  properties: {
+                    type: {
+                      $ref: #/components/schemas/string
+                    },
+                    title: {
+                      $ref: #/components/schemas/string
+                    },
+                    status: {
+                      type: integer,
+                      format: int32,
+                      nullable: true
+                    },
+                    detail: {
+                      $ref: #/components/schemas/string
+                    },
+                    instance: {
+                      $ref: #/components/schemas/string
+                    }
+                  }
+                },
+                example: {
+                  type: https://tools.ietf.org/html/rfc9110#section-15.6.1,
+                  title: Internal Server Error,
+                  status: 500,
+                  detail: An internal error occurred.,
+                  instance: /hello
+                }
+              }
+            }
           }
         }
+      }
+    }
+  },
+  components: {
+    schemas: {
+      string: {
+        type: string,
+        nullable: true
       }
     }
   },

--- a/tests/OpenApi.Extensions.Tests/DocumentTests.cs
+++ b/tests/OpenApi.Extensions.Tests/DocumentTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace MartinCostello.OpenApi;
@@ -21,8 +22,10 @@ public class DocumentTests(ITestOutputHelper outputHelper)
                 {
                     options.AddExamples = true;
                     options.AddServerUrls = true;
-                    options.AddXmlComments<Greeting>();
                     options.SerializationContext = AppJsonSerializationContext.Default;
+
+                    options.AddExample<ProblemDetails, ProblemDetailsExampleProvider>();
+                    options.AddXmlComments<Greeting>();
                 });
             },
             (endpoints) => { },

--- a/tests/OpenApi.Extensions.Tests/MartinCostello.OpenApi.Extensions.Tests.csproj
+++ b/tests/OpenApi.Extensions.Tests/MartinCostello.OpenApi.Extensions.Tests.csproj
@@ -34,7 +34,7 @@
   <PropertyGroup Condition=" '$(BuildingInsideVisualStudio)' != 'true' ">
     <CollectCoverage>true</CollectCoverage>
     <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
-    <Exclude>[*.Test*]*,[xunit.*]*</Exclude>
+    <Exclude>[*Test*]*,[xunit.*]*</Exclude>
     <ExcludeByAttribute>GeneratedCodeAttribute</ExcludeByAttribute>
     <Threshold>50</Threshold>
   </PropertyGroup>

--- a/tests/TestApp/AppJsonSerializationContext.cs
+++ b/tests/TestApp/AppJsonSerializationContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Mvc;
 
 namespace MartinCostello.OpenApi;
 
@@ -9,5 +10,6 @@ namespace MartinCostello.OpenApi;
 /// The <see cref="JsonSerializerContext"/> to use for the application. This class cannot be inherited.
 /// </summary>
 [JsonSerializable(typeof(Greeting))]
+[JsonSerializable(typeof(ProblemDetails))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, WriteIndented = true)]
 public sealed partial class AppJsonSerializationContext : JsonSerializerContext;

--- a/tests/TestApp/ProblemDetailsExampleProvider.cs
+++ b/tests/TestApp/ProblemDetailsExampleProvider.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace MartinCostello.OpenApi;
+
+/// <summary>
+/// A class representing an example provider for <see cref="ProblemDetails"/>.
+/// </summary>
+public sealed class ProblemDetailsExampleProvider : IExampleProvider<ProblemDetails>
+{
+    /// <inheritdoc/>
+    public static ProblemDetails GenerateExample()
+    {
+        return new()
+        {
+            Type = "https://tools.ietf.org/html/rfc9110#section-15.6.1",
+            Title = "Internal Server Error",
+            Status = StatusCodes.Status500InternalServerError,
+            Detail = "An internal error occurred.",
+            Instance = "/hello",
+        };
+    }
+}

--- a/tests/TestApp/Program.cs
+++ b/tests/TestApp/Program.cs
@@ -47,8 +47,8 @@ app.MapGet("/hello", (
     })
     .Produces<Greeting>(StatusCodes.Status200OK)
     .ProducesProblem(StatusCodes.Status400BadRequest)
-    .WithMetadata(new OpenApiResponseAttribute(StatusCodes.Status200OK, "A greeting."))
-    .WithMetadata(new OpenApiResponseAttribute(StatusCodes.Status400BadRequest, "No name was provided."));
+    .ProducesOpenApiResponse(StatusCodes.Status200OK, "A greeting.")
+    .ProducesOpenApiResponse(StatusCodes.Status400BadRequest, "No name was provided.");
 
 app.Run();
 


### PR DESCRIPTION
- Add support for examples for third-party types.
- Add new `ProducesOpenApiResponse` extension method to make it a bit terser to add `[OpenApiResponse]` metadata.
