### PR TITLE
Add TODO for removing [ShortRunJob]

### DIFF
--- a/perf/OpenApi.Extensions.Benchmarks/OpenApiBenchmarks.cs
+++ b/perf/OpenApi.Extensions.Benchmarks/OpenApiBenchmarks.cs
@@ -8,7 +8,7 @@ namespace MartinCostello.OpenApi;
 
 [EventPipeProfiler(EventPipeProfile.CpuSampling)]
 [MemoryDiagnoser]
-[ShortRunJob]
+[ShortRunJob] // TODO Remove once https://github.com/dotnet/aspnetcore/issues/56990 is resolved
 public class OpenApiBenchmarks : IAsyncDisposable
 {
     private TodoAppServer? _app = new();


### PR DESCRIPTION
Add TODO to use a normal benchmark job once the linked issue is resolved.
