### PR TITLE
Use stable NuGet packages

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
-    <packageSource key="dotnet9">
-      <package pattern="*" />
-    </packageSource>
     <packageSource key="NuGet">
       <package pattern="*" />
     </packageSource>


### PR DESCRIPTION
Use stable NuGet packages for .NET 9 preview 7.
