### PR TITLE
Handle getter-only properties

### DIFF
--- a/src/OpenApi.Extensions/Transformers/DescriptionsTransformer.cs
+++ b/src/OpenApi.Extensions/Transformers/DescriptionsTransformer.cs
@@ -58,9 +58,11 @@ internal sealed class DescriptionsTransformer(Func<string, string> transformer) 
 
     internal static string RemoveStyleCopPrefixes(string description)
     {
-        const string Prefix = "Gets or sets ";
+        const string GetSetPrefix = "Gets or sets ";
+        const string GetPrefix = "Gets ";
 
-        description = description.Replace(Prefix, string.Empty, StringComparison.Ordinal);
+        description = description.Replace(GetSetPrefix, string.Empty, StringComparison.Ordinal);
+        description = description.Replace(GetPrefix, string.Empty, StringComparison.Ordinal);
         description = char.ToUpperInvariant(description[0]) + description[1..];
 
         return description;

--- a/tests/Models.A/Dog.cs
+++ b/tests/Models.A/Dog.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Text.Json.Serialization;
 using MartinCostello.OpenApi;
 
 namespace Models.A;
@@ -15,6 +16,12 @@ public class Dog : Animal, IExampleProvider<Dog>
     /// Gets or sets the breed of the dog.
     /// </summary>
     public string? Breed { get; set; }
+
+    /// <summary>
+    /// Gets the age of the dog, if known.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public int? Age { get; init; }
 
     /// <inheritdoc/>
     public static Dog GenerateExample() => new()

--- a/tests/OpenApi.Extensions.Tests/IntegrationTests.Schema_Is_Correct_For_Classes.verified.txt
+++ b/tests/OpenApi.Extensions.Tests/IntegrationTests.Schema_Is_Correct_For_Classes.verified.txt
@@ -144,6 +144,12 @@
             description: The breed of the dog.,
             nullable: true
           },
+          age: {
+            type: integer,
+            description: The age of the dog, if known.,
+            format: int32,
+            nullable: true
+          },
           name: {
             type: string,
             description: The name of the animal.,

--- a/tests/OpenApi.Extensions.Tests/IntegrationTests.Schema_Is_Correct_For_Example_Attribute_Hierarchy.verified.txt
+++ b/tests/OpenApi.Extensions.Tests/IntegrationTests.Schema_Is_Correct_For_Example_Attribute_Hierarchy.verified.txt
@@ -369,6 +369,11 @@
             type: string,
             nullable: true
           },
+          age: {
+            type: integer,
+            format: int32,
+            nullable: true
+          },
           name: {
             type: string,
             nullable: true
@@ -384,6 +389,11 @@
         properties: {
           breed: {
             type: string,
+            nullable: true
+          },
+          age: {
+            type: integer,
+            format: int32,
             nullable: true
           },
           name: {


### PR DESCRIPTION
Extend the StyleCop prefix transformer to include get-only properties (_"Gets a value..."_).
