### PR TITLE
Update NuGet packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,8 +17,8 @@
     <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.6.21" />
     <PackageVersion Include="ReportGenerator" Version="5.3.9" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
-    <PackageVersion Include="Verify.Xunit" Version="26.4.4" />
-    <PackageVersion Include="xunit" Version="2.9.0" />
+    <PackageVersion Include="Verify.Xunit" Version="26.6.0" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Update NuGet packages to their latest versions while dependabot does not support .NET 9.
