### PR TITLE
Bump NuGet packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <ItemGroup>
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
-    <GlobalPackageReference Include="ReferenceTrimmer" Version="3.3.6" PrivateAssets="All" />
+    <GlobalPackageReference Include="ReferenceTrimmer" Version="3.3.10" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
@@ -13,9 +13,9 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0-rc.1.24451.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageVersion Include="Microsoft.OpenApi" Version="1.6.21" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="1.6.22" />
     <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.6.21" />
-    <PackageVersion Include="ReportGenerator" Version="5.3.9" />
+    <PackageVersion Include="ReportGenerator" Version="5.3.10" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="Verify.Xunit" Version="26.6.0" />
     <PackageVersion Include="xunit" Version="2.9.2" />


### PR DESCRIPTION
Update NuGet packages while dependabot doesn't support .NET 9.
