### PR TITLE
Update to .NET 9 RTM

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,8 +27,6 @@
     <LangVersion>latest</LangVersion>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <!-- TODO Enable when .NET 9 is stable -->
-    <NoWarn>$(NoWarn);CS9057;NU5104</NoWarn>
     <Nullable>enable</Nullable>
     <PackageIcon>package-icon.png</PackageIcon>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,10 +8,10 @@
     <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.4.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0-rc.2.24474.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0-rc.2.24474.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0-rc.2.24474.1" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Microsoft.OpenApi" Version="1.6.22" />
     <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.6.22" />

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # OpenAPI Extensions for ASP.NET Core
 
-> [!NOTE]
-> This project is currently experimental and depends on pre-releases of [ASP.NET Core 9][aspnetcore-9].
-
 [![NuGet][package-badge-version]][package-download]
 [![NuGet Downloads][package-badge-downloads]][package-download]
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,6 @@ The repository is hosted in [GitHub][repo]: <https://github.com/martincostello/o
 
 This project is licensed under the [Apache 2.0][license] license.
 
-[aspnetcore-9]: https://learn.microsoft.com/aspnet/core/release-notes/aspnetcore-9.0
 [aspnetcore-native-aot]: https://learn.microsoft.com/aspnet/core/fundamentals/native-aot "ASP.NET Core support for Native AOT"
 [aspnetcore-openapi]: https://www.nuget.org/packages/Microsoft.AspNetCore.OpenApi
 [build-badge]: https://github.com/martincostello/openapi-extensions/actions/workflows/build.yml/badge.svg?branch=main&event=push

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100-rc.2.24474.11",
+    "version": "9.0.100",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/src/OpenApi.Extensions/MartinCostello.OpenApi.Extensions.csproj
+++ b/src/OpenApi.Extensions/MartinCostello.OpenApi.Extensions.csproj
@@ -11,6 +11,7 @@
     <OutputType>Library</OutputType>
     <PackageId>MartinCostello.OpenApi.Extensions</PackageId>
     <!--
+    TODO Enable and update PublicAPI baselines once 1.0.0 published
     <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion>
     -->
     <RootNamespace>MartinCostello.OpenApi</RootNamespace>

--- a/src/OpenApi.Extensions/OpenApiEndpointRouteBuilderExtensions.cs
+++ b/src/OpenApi.Extensions/OpenApiEndpointRouteBuilderExtensions.cs
@@ -134,7 +134,7 @@ public static class OpenApiEndpointRouteBuilderExtensions
             string documentName,
             [NotNullWhen(true)] out object? instance)
         {
-            // TODO Simplify when API proposal implemented: https://github.com/dotnet/runtime/issues/105828
+            // TODO Simplify when API proposal implemented: https://github.com/dotnet/runtime/issues/102816
             if (serviceProvider is IKeyedServiceProvider keyedServiceProvider)
             {
                 instance = keyedServiceProvider.GetKeyedService(_documentService, documentName);


### PR DESCRIPTION
- Update to stable version of .NET 9 SDK and NuGet packages.
- Add TODO for package validation and public APIs.
- Update TODO link to point to correct issue.
