### PR TITLE
Extend example provider

### DIFF
--- a/src/OpenApi.Extensions/OpenApiExtensionsOptions.cs
+++ b/src/OpenApi.Extensions/OpenApiExtensionsOptions.cs
@@ -84,6 +84,17 @@ public class OpenApiExtensionsOptions
     public IList<Assembly> XmlDocumentationAssemblies { get; } = [];
 
     /// <summary>
+    /// Adds the specified type as its own example provider to the options.
+    /// </summary>
+    /// <typeparam name="TSchema">The type of the schema.</typeparam>
+    /// <returns>
+    /// The current instance of <see cref="OpenApiExtensionsOptions"/>.
+    /// </returns>
+    public OpenApiExtensionsOptions AddExample<TSchema>()
+        where TSchema : IExampleProvider<TSchema>
+        => AddExample<TSchema, TSchema>();
+
+    /// <summary>
     /// Adds an example provider for the specified type to the options.
     /// </summary>
     /// <typeparam name="TSchema">The type of the schema.</typeparam>

--- a/src/OpenApi.Extensions/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/OpenApi.Extensions/PublicAPI/PublicAPI.Unshipped.txt
@@ -17,6 +17,7 @@ MartinCostello.OpenApi.OpenApiExampleAttribute<TSchema, TProvider>.OpenApiExampl
 MartinCostello.OpenApi.OpenApiExtensions
 MartinCostello.OpenApi.OpenApiExtensionsOptions
 MartinCostello.OpenApi.OpenApiExtensionsOptions.AddExample<TSchema, TProvider>() -> MartinCostello.OpenApi.OpenApiExtensionsOptions!
+MartinCostello.OpenApi.OpenApiExtensionsOptions.AddExample<TSchema>() -> MartinCostello.OpenApi.OpenApiExtensionsOptions!
 MartinCostello.OpenApi.OpenApiExtensionsOptions.AddExamples.get -> bool
 MartinCostello.OpenApi.OpenApiExtensionsOptions.AddExamples.set -> void
 MartinCostello.OpenApi.OpenApiExtensionsOptions.AddServerUrls.get -> bool

--- a/src/OpenApi.Extensions/Transformers/AddExamplesTransformer.cs
+++ b/src/OpenApi.Extensions/Transformers/AddExamplesTransformer.cs
@@ -230,7 +230,19 @@ internal sealed class AddExamplesTransformer(
                     return null;
                 }
 
-                return _typeMetadata.TryGetValue(key.Type, out metadata) ? metadata : null;
+                var targetType = key.Type;
+
+                while (targetType is not null)
+                {
+                    if (_typeMetadata.TryGetValue(targetType, out metadata))
+                    {
+                        return metadata;
+                    }
+
+                    targetType = targetType.BaseType;
+                }
+
+                return null;
             });
         }
 

--- a/tests/Models.A/Dog.cs
+++ b/tests/Models.A/Dog.cs
@@ -9,7 +9,6 @@ namespace Models.A;
 /// <summary>
 /// A class representing a dog. Secret.
 /// </summary>
-[OpenApiExample<Dog>]
 public class Dog : Animal, IExampleProvider<Dog>
 {
     /// <summary>

--- a/tests/OpenApi.Extensions.Tests/IntegrationTests.Schema_Is_Correct_For_Classes.verified.txt
+++ b/tests/OpenApi.Extensions.Tests/IntegrationTests.Schema_Is_Correct_For_Classes.verified.txt
@@ -40,6 +40,9 @@
             application/json: {
               schema: {
                 $ref: #/components/schemas/Cat
+              },
+              example: {
+                Name: Donald
               }
             }
           },
@@ -131,7 +134,10 @@
             nullable: true
           }
         },
-        description: A class representing a cat.
+        description: A class representing a cat.,
+        example: {
+          Name: Donald
+        }
       },
       Dog: {
         type: object,

--- a/tests/OpenApi.Extensions.Tests/IntegrationTests.cs
+++ b/tests/OpenApi.Extensions.Tests/IntegrationTests.cs
@@ -136,6 +136,8 @@ public class IntegrationTests(ITestOutputHelper outputHelper) : DocumentTests(ou
                     options.SerializationContexts.Add(AnimalsJsonSerializationContext.Default);
 
                     options.AddExample<Animal, AnimalExampleProvider>();
+                    options.AddExample<Dog>();
+
                     options.AddXmlComments<Animal>();
 
                     options.DescriptionTransformations.Add((p) => p.Replace(" Secret.", string.Empty, StringComparison.Ordinal));
@@ -281,6 +283,7 @@ public class IntegrationTests(ITestOutputHelper outputHelper) : DocumentTests(ou
                 {
                     options.AddExamples = true;
                     options.AddExample<Car, CarExampleProvider>();
+                    options.AddExample<Dog>();
 
                     options.SerializationContexts.Add(AnimalsJsonSerializationContext.Default);
                     options.SerializationContexts.Add(VehiclesJsonSerializationContext.Default);


### PR DESCRIPTION
- Support using examples for base classes.
- Add `AddExample<T>` example for types that are their own example provider.
