### PR TITLE
Set JsonNumberHandling.Strict

### DIFF
--- a/samples/TodoApp/ApiEndpoints.cs
+++ b/samples/TodoApp/ApiEndpoints.cs
@@ -55,6 +55,10 @@ public static class ApiEndpoints
         // Configure JSON source generation for the Todo API
         services.ConfigureHttpJsonOptions((options) =>
         {
+            options.SerializerOptions.DefaultIgnoreCondition = TodoJsonSerializerContext.Default.Options.DefaultIgnoreCondition;
+            options.SerializerOptions.NumberHandling = TodoJsonSerializerContext.Default.Options.NumberHandling;
+            options.SerializerOptions.PropertyNamingPolicy = TodoJsonSerializerContext.Default.Options.PropertyNamingPolicy;
+            options.SerializerOptions.WriteIndented = TodoJsonSerializerContext.Default.Options.WriteIndented;
             options.SerializerOptions.TypeInfoResolverChain.Add(TodoJsonSerializerContext.Default);
         });
 

--- a/samples/TodoApp/TodoJsonSerializerContext.cs
+++ b/samples/TodoApp/TodoJsonSerializerContext.cs
@@ -22,6 +22,7 @@ namespace TodoApp;
 [JsonSerializable(typeof(TodoListViewModel))]
 [JsonSourceGenerationOptions(
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    NumberHandling = JsonNumberHandling.Strict,
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     WriteIndented = true)]
 public sealed partial class TodoJsonSerializerContext : JsonSerializerContext;

--- a/tests/OpenApi.Extensions.Tests/OpenApiExampleAttributeTests.cs
+++ b/tests/OpenApi.Extensions.Tests/OpenApiExampleAttributeTests.cs
@@ -134,10 +134,14 @@ public static partial class OpenApiExampleAttributeTests
     }
 
     [JsonSerializable(typeof(Person))]
-    [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+    [JsonSourceGenerationOptions(
+        NumberHandling = JsonNumberHandling.Strict,
+        PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
     private sealed partial class PersonJsonSerializationContextCamel : JsonSerializerContext;
 
     [JsonSerializable(typeof(Person))]
-    [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.Unspecified)]
+    [JsonSourceGenerationOptions(
+        NumberHandling = JsonNumberHandling.Strict,
+        PropertyNamingPolicy = JsonKnownNamingPolicy.Unspecified)]
     private sealed partial class PersonJsonSerializationContextPascal : JsonSerializerContext;
 }

--- a/tests/TestApp/AppJsonSerializationContext.cs
+++ b/tests/TestApp/AppJsonSerializationContext.cs
@@ -12,5 +12,8 @@ namespace MartinCostello.OpenApi;
 [JsonSerializable(typeof(Greeting))]
 [JsonSerializable(typeof(ProblemDetails))]
 [JsonSerializable(typeof(string))]
-[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, WriteIndented = true)]
+[JsonSourceGenerationOptions(
+    NumberHandling = JsonNumberHandling.Strict,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    WriteIndented = true)]
 public sealed partial class AppJsonSerializationContext : JsonSerializerContext;

--- a/tests/WebApi/MvcSerializerContext.cs
+++ b/tests/WebApi/MvcSerializerContext.cs
@@ -10,6 +10,7 @@ namespace MartinCostello.WebApi;
 [JsonSerializable(typeof(TimeModel))]
 [JsonSourceGenerationOptions(
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    NumberHandling = JsonNumberHandling.Strict,
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     WriteIndented = true)]
 public sealed partial class MvcSerializerContext : JsonSerializerContext;


### PR DESCRIPTION
Set `JsonNumberHandling.Strict` for JSON serialization to avoid behaviour change with OpenAPI in .NET 10.
