### PR TITLE
Fail benchmarks if any errors

### DIFF
--- a/benchmark.ps1
+++ b/benchmark.ps1
@@ -91,3 +91,8 @@ if (-Not [string]::IsNullOrEmpty(${env:GITHUB_SHA})) {
 }
 
 & $dotnet run --project $benchmarks --configuration "Release" --framework "net9.0" -- $additionalArgs
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Benchmarks failed with exit code $LASTEXITCODE."
+    exit $LASTEXITCODE
+}

--- a/perf/OpenApi.Extensions.Benchmarks/Program.cs
+++ b/perf/OpenApi.Extensions.Benchmarks/Program.cs
@@ -18,8 +18,11 @@ if (args.SequenceEqual(["--test"]))
     {
         await benchmarks.StopServer();
     }
+
+    return 0;
 }
 else
 {
-    BenchmarkRunner.Run<OpenApiBenchmarks>(args: args);
+    var summary = BenchmarkRunner.Run<OpenApiBenchmarks>(args: args);
+    return summary.Reports.Any((p) => !p.Success) ? 1 : 0;
 }


### PR DESCRIPTION
Fail the benchmarks if any errors are encountered during execution.
