### PR TITLE
Replace codecov/test-results-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,10 +83,11 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Upload test results to Codecov
-      uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+      uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
       if: ${{ !cancelled() }}
       with:
         flags: ${{ matrix.os-name }}
+        report_type: test_results
         token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Generate SBOM


### PR DESCRIPTION
Migrate from deprecated action to codecov/codecov-action.
