### PR TITLE
Skip benchmark publish in forks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -68,6 +68,7 @@ jobs:
 
     - name: Get GitHub token
       id: get-github-token
+      if: github.event.repository.fork == false
       # zizmor: ignore[ref-version-mismatch] False positive
       uses: martincostello/github-automation/actions/get-github-token@16711f5c6f94e59ee14b83697acb675be1528856 # get-github-token/v4.1.0
       with:
@@ -75,6 +76,7 @@ jobs:
 
     - name: Publish results
       uses: martincostello/benchmarkdotnet-results-publisher@0f2a458a28dbd963b1bcb029efaec245b677c7b3 # v2.0.3
+      if: github.event.repository.fork == false
       with:
         branch: ${{ github.ref_name }}
         comment-on-threshold: true


### PR DESCRIPTION
Do not attempt to publish benchmark results from forks.
