### PR TITLE
Update Microsoft.OpenApi to 2.7.5

### DIFF
--- a/src/OpenApi.Extensions/MartinCostello.OpenApi.Extensions.csproj
+++ b/src/OpenApi.Extensions/MartinCostello.OpenApi.Extensions.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
     <PackageReference Update="Microsoft.AspNetCore.OpenApi" VersionOverride="[10.0.0,)" />
-    <PackageReference Update="Microsoft.OpenApi" VersionOverride="[2.0.0,)" />
+    <PackageReference Update="Microsoft.OpenApi" VersionOverride="[2.7.5,)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />


### PR DESCRIPTION
Update Microsoft.OpenApi to 2.7.5 to pick up fix for GHSA-v5pm-xwqc-g5wc.
