### PR TITLE
Revert "Bump openapi-dotnet monorepo"

### DIFF
--- a/src/OpenApi.Extensions/MartinCostello.OpenApi.Extensions.csproj
+++ b/src/OpenApi.Extensions/MartinCostello.OpenApi.Extensions.csproj
@@ -17,11 +17,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" VersionOverride="[9.0.0,)" />
-    <PackageReference Include="Microsoft.OpenApi" VersionOverride="[1.6.29,)" />
+    <PackageReference Include="Microsoft.OpenApi" VersionOverride="[1.6.25,)" />
   </ItemGroup>
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
     <PackageReference Update="Microsoft.AspNetCore.OpenApi" VersionOverride="[10.0.0,)" />
-    <PackageReference Update="Microsoft.OpenApi" VersionOverride="[2.8.0,)" />
+    <PackageReference Update="Microsoft.OpenApi" VersionOverride="[2.7.5,)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />


### PR DESCRIPTION
Reverts martincostello/openapi-extensions#876 as it was an unwanted changes that got auto-merged before I could close it.