### PR TITLE
Fix CI

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,4 +14,8 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);419;1570;1573;1574;1584;1591;SA0001;SA1602</NoWarn>
   </PropertyGroup>
+  <!-- HACK Workaround until fix from https://github.com/dotnet/efcore/pull/38402 is available -->
+  <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Suppress GHSA-2m69-gcr7-jv3q until a patched version of EFCore is available.
