### PR TITLE
Skip job for prereleases

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -16,7 +16,7 @@ permissions: {}
 jobs:
   bump-version:
     runs-on: ubuntu-24.04
-    if: github.event.repository.fork == false
+    if: github.event.repository.fork == false && !contains(github.event.release.tag_name, '-')
 
     concurrency:
       group: '${{ github.workflow }}-bump'

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -16,7 +16,7 @@ permissions: {}
 jobs:
   bump-version:
     runs-on: ubuntu-24.04
-    if: github.event.repository.fork == false && !contains(github.event.release.tag_name, '-')
+    if: github.event.repository.fork == false && (github.event_name != 'release' || github.event.release.prerelease == false)
 
     concurrency:
       group: '${{ github.workflow }}-bump'


### PR DESCRIPTION
Skip the version bump workflow if the released tag is a prerelease.
